### PR TITLE
Clean up JS

### DIFF
--- a/ide/.gitignore
+++ b/ide/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 out
+test
 .vscode-test

--- a/ide/build.cjs
+++ b/ide/build.cjs
@@ -25,7 +25,7 @@ let common = {
 };
 
 let extension = estrella.build({
-  entryPoints: ["src/extension.ts", "src/tests/slice/util/slice_helpers.ts"],
+  entryPoints: ["src/extension.ts"],
   platform: "node",
   ...common
 });
@@ -35,6 +35,13 @@ let page = estrella.build({
   ...common
 });
 
-Promise.all([extension, page])
+let test = estrella.build({
+  entryPoints: ["src/extension.ts", "src/tests/slice/util/slice_helpers.ts"],
+  platform: "node",
+  ...common,
+  outdir: "test",
+});
+
+Promise.all([extension, page, test])
   .then(() => console.log("Build complete."))
   .catch(() => process.exit(1));

--- a/ide/package.json
+++ b/ide/package.json
@@ -90,8 +90,8 @@
     "build": "node build.cjs",
     "watch": "node build.cjs -w",
     "tc": "tsc",
-    "pretest": "npm run tc && npm run build",
-    "test": "node ./out/tests/runTests.js"
+    "pretest": "tsc --outDir test && npm run build",
+    "test": "node ./test/tests/runTests.js"
   },
   "devDependencies": {
     "@types/adm-zip": "^0.4.34",

--- a/ide/src/setup.ts
+++ b/ide/src/setup.ts
@@ -198,8 +198,8 @@ export async function setup(
   );
 
   return async <T>(args: string) => {
-    let cmd = `${flowistry_cmd} ${args}`; // connor: flowistry_cmd
-    let flowisty_opts = get_flowistry_opts(workspace_root);
+    let cmd = `${flowistry_cmd} ${args}`;
+    let flowisty_opts = await get_flowistry_opts(workspace_root);
 
     let output;
     try {

--- a/ide/src/setup.ts
+++ b/ide/src/setup.ts
@@ -16,6 +16,37 @@ declare const TOOLCHAIN: {
 
 const SHOW_LOADER_THRESHOLD = 2000;
 
+const LIBRARY_PATHS: Partial<Record<NodeJS.Platform, string>> = {
+  darwin: "DYLD_LIBRARY_PATH",
+  win32: "LIB",
+};
+
+export const flowistry_cmd = `cargo +${TOOLCHAIN.channel} flowistry`;
+
+export const get_flowistry_opts = async (cwd: string) => {
+  const rustc_path = await exec_notify(
+    `rustup which --toolchain ${TOOLCHAIN.channel} rustc`,
+    "Waiting for rustc..."
+  );
+  const target_info = await exec_notify(
+    `${rustc_path} --print target-libdir --print sysroot`,
+    "Waiting for rustc..."
+  );
+
+  const [target_libdir, sysroot] = target_info.split("\n");
+  log("Target libdir:", target_libdir);
+  log("Sysroot: ", sysroot);
+
+  const library_path = LIBRARY_PATHS[process.platform] || "LD_LIBRARY_PATH";
+
+  return {
+    cwd,
+    [library_path]: target_libdir,
+    SYSROOT: sysroot,
+    RUST_BACKTRACE: "1",
+  };
+};
+
 export let exec_notify = async (
   cmd: string,
   title: string,
@@ -146,18 +177,6 @@ export async function setup(
     }
   }
 
-  let rustc_path = await exec_notify(
-    `rustup which --toolchain ${TOOLCHAIN.channel} rustc`,
-    "Waiting for rustc..."
-  );
-  let target_info = await exec_notify(
-    `${rustc_path} --print target-libdir --print sysroot`,
-    "Waiting for rustc..."
-  );
-  let [target_libdir, sysroot] = target_info.split("\n");
-  log("Target libdir:", target_libdir);
-  log("Sysroot: ", sysroot);
-
   const tdcp = new (class implements vscode.TextDocumentContentProvider {
     readonly uri = vscode.Uri.parse("flowistry://build-error");
     readonly eventEmitter = new vscode.EventEmitter<vscode.Uri>();
@@ -179,15 +198,8 @@ export async function setup(
   );
 
   return async <T>(args: string) => {
-    let cmd = `${cargo} flowistry ${args}`;
-    let library_path;
-    if (process.platform == "darwin") {
-      library_path = "DYLD_LIBRARY_PATH";
-    } else if (process.platform == "win32") {
-      library_path = "LIB";
-    } else {
-      library_path = "LD_LIBRARY_PATH";
-    }
+    let cmd = `${flowistry_cmd} ${args}`; // connor: flowistry_cmd
+    let flowisty_opts = get_flowistry_opts(workspace_root);
 
     let output;
     try {
@@ -196,12 +208,7 @@ export async function setup(
         await editor.document.save();
       }
 
-      output = await exec_notify(cmd, "Waiting for Flowistry...", {
-        cwd: workspace_root,
-        [library_path]: target_libdir,
-        SYSROOT: sysroot,
-        RUST_BACKTRACE: "1",
-      });
+      output = await exec_notify(cmd, "Waiting for Flowistry...", flowisty_opts);
     } catch (e: any) {
       tdcp.contents = e.toString();
       tdcp.eventEmitter.fire(tdcp.uri);

--- a/ide/src/tests/install/install.test.ts
+++ b/ide/src/tests/install/install.test.ts
@@ -5,7 +5,7 @@ import waitForExpect from "wait-for-expect";
 
 const flowistryCommandsExist = async () => {
     const commands = await vscode.commands.getCommands();
-    return commands.filter((command) => command.includes('flowistry.')).length > 0;
+    return commands.find(command => command.startsWith('flowistry.'));
 };
 
 suite("Flowistry installation tests", () => {
@@ -16,7 +16,7 @@ suite("Flowistry installation tests", () => {
 
         // Wait for Flowistry commands to exist, polling every second for 50 seconds
         await waitForExpect(async () => {
-            expect(await flowistryCommandsExist()).to.be.true;
+            expect(await flowistryCommandsExist()).is.not.undefined;
         }, timeout, interval);
     }).timeout(timeout);
 });

--- a/ide/src/tests/slice/select.test.ts
+++ b/ide/src/tests/slice/select.test.ts
@@ -2,27 +2,23 @@ import chai, { expect } from "chai";
 import deepEqualAnyOrder from 'deep-equal-in-any-order';
 import { suite, before, test } from "mocha";
 import _ from "lodash";
-import { forward_slices, backward_slices } from "./mock_data/slices";
+import { forward_slices, backward_slices, TestSlice } from "./mock_data/slices";
 import { get_slice_selections, resolve_sequentially } from "./util/slice_helpers";
+
+const slice_test = (slices: TestSlice[]) => async () => {
+  const selections = await resolve_sequentially(slices, get_slice_selections);
+
+  selections.forEach(async (selection) => {
+    expect(selection.expected_selections).to.be.deep.equalInAnyOrder(selection.actual_selections);
+  });
+}
 
 suite("Slice selection tests", async () => {
   before(() => {
     chai.use(deepEqualAnyOrder);
   });
 
-  test("forward select", async () => {
-    const forward_selections = await resolve_sequentially(forward_slices, get_slice_selections);
+  test("forward select", slice_test(forward_slices));
 
-    forward_selections.forEach(async (selection) => {
-      expect(selection.expected_selections).to.be.deep.equalInAnyOrder(selection.actual_selections);
-    });
-  });
-
-  test("backward select", async () => {
-    const backward_selections = await resolve_sequentially(backward_slices, get_slice_selections);
-
-    backward_selections.forEach(async (selection) => {
-      expect(selection.expected_selections).to.be.deep.equalInAnyOrder(selection.actual_selections);
-    });
-  });
+  test("backward select", slice_test(backward_slices));
 });

--- a/ide/src/tests/slice/util/slice_helpers.ts
+++ b/ide/src/tests/slice/util/slice_helpers.ts
@@ -22,7 +22,7 @@ export const get_slice = async ({ test, file, direction, slice_on }: TestSlice):
     const start = doc.offsetAt(new vscode.Position(...slice_on[0]));
     const end = doc.offsetAt(new vscode.Position(...slice_on[1]));
     const slice_command = `${flowistry_cmd} ${direction}_slice ${file} ${start} ${end}`;
-    const command_opts = get_flowistry_opts(MOCK_PROJECT_DIRECTORY);
+    const command_opts = await get_flowistry_opts(MOCK_PROJECT_DIRECTORY);
 
     const output = await exec_notify(slice_command, test, command_opts);
 

--- a/ide/src/tests/slice/util/slice_helpers.ts
+++ b/ide/src/tests/slice/util/slice_helpers.ts
@@ -89,7 +89,7 @@ const merge_ranges = (ranges: vscode.Range[]): vscode.Range[] => {
     const merged_ranges = [ranges[0]];
 
     ranges.slice(1).forEach((range) => {
-        const last_range = merged_ranges[merged_ranges.length - 1];
+        const last_range = _.last(merged_ranges)!;
         const intersection = last_range.intersection(range);
 
         // If the current and previous ranges have no overlap

--- a/ide/src/tests/slice/util/slice_helpers.ts
+++ b/ide/src/tests/slice/util/slice_helpers.ts
@@ -1,20 +1,10 @@
 import _ from "lodash";
 import vscode from "vscode";
-import { exec_notify } from "../../../setup";
+import { exec_notify, flowistry_cmd, get_flowistry_opts } from "../../../setup";
 import { SliceOutput } from "../../../types";
 import { to_vsc_range } from "../../../vsc_utils";
 import { TestSlice } from "../mock_data/slices";
 import { MOCK_PROJECT_DIRECTORY } from "../../constants";
-
-export declare const TOOLCHAIN: {
-    channel: string;
-    components: string[];
-};
-
-const LIBRARY_PATHS: Partial<Record<NodeJS.Platform, string>> = {
-    darwin: "DYLD_LIBRARY_PATH",
-    win32: "LIB",
-};
 
 type TestSliceResult = {
     test: string;
@@ -31,26 +21,10 @@ export const get_slice = async ({ test, file, direction, slice_on }: TestSlice):
     const doc = vscode.window.activeTextEditor?.document!;
     const start = doc.offsetAt(new vscode.Position(...slice_on[0]));
     const end = doc.offsetAt(new vscode.Position(...slice_on[1]));
-    const flowistry_cmd = `cargo +${TOOLCHAIN.channel} flowistry`;
     const slice_command = `${flowistry_cmd} ${direction}_slice ${file} ${start} ${end}`;
+    const command_opts = get_flowistry_opts(MOCK_PROJECT_DIRECTORY);
 
-    const rustc_path = await exec_notify(
-        `rustup which --toolchain ${TOOLCHAIN.channel} rustc`,
-        "Waiting for rustc..."
-    );
-    const target_info = await exec_notify(
-        `${rustc_path} --print target-libdir --print sysroot`,
-        "Waiting for rustc..."
-    );
-    const [target_libdir, sysroot] = target_info.split("\n");
-    const library_path = LIBRARY_PATHS[process.platform] || "LD_LIBRARY_PATH";
-
-    const output = await exec_notify(slice_command, test, {
-        cwd: MOCK_PROJECT_DIRECTORY,
-        [library_path]: target_libdir,
-        SYSROOT: sysroot,
-        RUST_BACKTRACE: "1",
-    });
+    const output = await exec_notify(slice_command, test, command_opts);
 
     return output;
 };


### PR DESCRIPTION
Adds:

- Currying for slice testing functions
- Better use of builtin and lodash functions
- Uses `test/` as `outDir` for building the extension test files
- Shares Flowistry command and options between `setup.ts` and `slice_helpers.ts`